### PR TITLE
Alphabetizing list of languages

### DIFF
--- a/PYPL/All.js
+++ b/PYPL/All.js
@@ -5,7 +5,7 @@ PlusMinus = [-0.09218338132901766,0.20021895238029025]
 // end Top All
 graphData = [
 ['Date', // begin section languages
-'Abap', 'Ada', 'C/C++', 'C#', 'Cobol', 'Dart', 'Delphi', 'Go', 'Groovy', 'Haskell', 'Julia', 'Kotlin', 'Java', 'Javascript', 'Lua', 'Matlab', 'Objective-C', 'Perl', 'PHP', 'Python', 'R', 'Ruby', 'Rust', 'Scala', 'Swift', 'TypeScript', 'VBA', 'Visual Basic'
+'Abap', 'Ada', 'C/C++', 'C#', 'Cobol', 'Dart', 'Delphi', 'Go', 'Groovy', 'Haskell', 'Java', 'JavaScript', 'Julia', 'Kotlin', 'Lua', 'Matlab', 'Objective-C', 'Perl', 'PHP', 'Python', 'R', 'Ruby', 'Rust', 'Scala', 'Swift', 'TypeScript', 'VBA', 'Visual Basic'
 // end section languages
 ],
 // begin section All


### PR DESCRIPTION
Java and JavaScript were listed out of alphabetical order, in this PR I am merely putting them in the more correct order. Also stylizing the name of JavaScript &mdash; the 's' wasn't capitalized and it's meant to be. 